### PR TITLE
Typo in example code

### DIFF
--- a/inst/README.Rmd
+++ b/inst/README.Rmd
@@ -62,7 +62,7 @@ the `return.vs.es` option from it's `.onLoad` function:
 
 ```r
 .onLoad <- function(lib, pkg) {
-    pkgconfig::set_config("igraph:return.vs.es" = FALSE)
+    pkgconfig::set_config("igraph::return.vs.es" = FALSE)
 }
 ```
 


### PR DESCRIPTION
Single colon vs double colon after package name.